### PR TITLE
Introduced Line height & uppercased Options

### DIFF
--- a/TextStyle/Source/Extensions/Attributes.swift
+++ b/TextStyle/Source/Extensions/Attributes.swift
@@ -15,12 +15,27 @@ extension TextStyle {
         
         attributes[.foregroundColor] = color
         attributes[.font] = font
-        attributes[.paragraphStyle] = alignment.flatMap { alignment in
-            let paragraphStyle = NSMutableParagraphStyle()
-            paragraphStyle.alignment = alignment
-            return paragraphStyle
-        }
+        attributes[.paragraphStyle] = paragraphStyle
         
         return attributes
+    }
+
+    private var paragraphStyle: NSMutableParagraphStyle? {
+        if lineHeight == nil && alignment == nil {
+            return nil
+        }
+
+        let paragraphStyle = NSMutableParagraphStyle()
+
+        if let alignment = alignment {
+            paragraphStyle.alignment = alignment
+        }
+
+        if let lineHeight = lineHeight {
+            paragraphStyle.minimumLineHeight = lineHeight
+            paragraphStyle.maximumLineHeight = lineHeight
+        }
+
+        return paragraphStyle
     }
 }

--- a/TextStyle/Source/Extensions/String.swift
+++ b/TextStyle/Source/Extensions/String.swift
@@ -10,7 +10,8 @@ import Foundation
 
 extension String {
     public func with(textStyle: TextStyle) -> NSAttributedString {
-        return NSAttributedString(string: self, attributes: textStyle.attributes)
+        let string = textStyle.uppercased ? self.uppercased() : self
+        return NSAttributedString(string: string, attributes: textStyle.attributes)
     }
     public func with(textStyle: TextStyle, forRange range: NSRange) -> NSAttributedString {
         return NSAttributedString(string: self).with(textStyle: textStyle, forRange: range)
@@ -23,6 +24,11 @@ extension NSAttributedString {
     }
     public func with(textStyle: TextStyle, forRange range: NSRange) -> NSAttributedString {
         let mutable = self as? NSMutableAttributedString ?? NSMutableAttributedString(attributedString: self)
+
+        if textStyle.uppercased {
+            mutable.mutableString.setString(string.uppercased())
+        }
+
         mutable.addAttributes(textStyle.attributes, range: range)
         return mutable
     }

--- a/TextStyle/Source/Extensions/UILabel.swift
+++ b/TextStyle/Source/Extensions/UILabel.swift
@@ -21,7 +21,16 @@ extension UILabel: TextStylable {
         if let textAlignment = textStyle.alignment {
             self.textAlignment = textAlignment
         }
+
+        if textStyle.lineHeight != nil {
+            print("Setting Line Height directly on UILabel not supported, use String().with(textStyle: TextStyle) -> NSAttributedString")
+        }
+
+        if textStyle.uppercased == true {
+            print("Setting uppercased directly on UILabel not supported, use String().with(textStyle: TextStyle) -> NSAttributedString")
+        }
     }
+
 }
 
 // MARK: Interface Builder

--- a/TextStyle/Source/Extensions/UITextField.swift
+++ b/TextStyle/Source/Extensions/UITextField.swift
@@ -21,6 +21,14 @@ extension UITextField: TextStylable {
         if let textAlignment = textStyle.alignment {
             self.textAlignment = textAlignment
         }
+
+        if textStyle.lineHeight != nil {
+            print("Setting Line Height directly on UITextField not supported, use String().with(textStyle: TextStyle) -> NSAttributedString")
+        }
+
+        if textStyle.uppercased == true {
+            print("Setting uppercased directly on UITextField not supported, use String().with(textStyle: TextStyle) -> NSAttributedString")
+        }
     }
 }
 

--- a/TextStyle/Source/Extensions/UITextView.swift
+++ b/TextStyle/Source/Extensions/UITextView.swift
@@ -21,6 +21,14 @@ extension UITextView: TextStylable {
         if let textAlignment = textStyle.alignment {
             self.textAlignment = textAlignment
         }
+
+        if textStyle.lineHeight != nil {
+            print("Setting Line Height directly on UITextView not supported, use String().with(textStyle: TextStyle) -> NSAttributedString")
+        }
+
+        if textStyle.uppercased == true {
+            print("Setting uppercased directly on UITextView not supported, use String().with(textStyle: TextStyle) -> NSAttributedString")
+        }
     }
 }
 

--- a/TextStyle/Source/TextStyle.swift
+++ b/TextStyle/Source/TextStyle.swift
@@ -32,6 +32,8 @@ public struct TextStyle {
     var font: UIFont?
     var color: UIColor?
     var alignment: NSTextAlignment?
+    var lineHeight: CGFloat?
+    var uppercased: Bool = false
     
     public init(){}
 }
@@ -51,5 +53,11 @@ public extension TextStyle {
     }
     func with(alignment: NSTextAlignment) -> TextStyle {
         return with({ $0.alignment = alignment })
+    }
+    func with(lineHeight: CGFloat) -> TextStyle {
+        return with({ $0.lineHeight = lineHeight })
+    }
+    func with(uppercased: Bool) -> TextStyle {
+        return with({ $0.uppercased = uppercased })
     }
 }

--- a/TextStyleExample/ViewController.swift
+++ b/TextStyleExample/ViewController.swift
@@ -24,6 +24,8 @@ class ViewController: UIViewController {
                 .with(font: .italicSystemFont(ofSize: 18))
                 .with(color: .gray)
                 .with(alignment: .right)
+                .with(lineHeight: 50.0)
+                .with(uppercased: true)
             
             attributedLabel.attributedText = "Attributed string\nFrom code".with(textStyle: style)
         }


### PR DESCRIPTION
Added lineHeight & uppercase cases to `.with` functions.
Added warnings when trying to use them on UILabel etc, as it is not possible to set lineHeight straight on UILabel without modifying text/attributedText variable of UILabel. User should with String.with(TextStyle) for such behaviour on UILabels & co